### PR TITLE
#71197: Search in folder 'resources' only

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/resourcelist/task/ResourceListFileTask.kt
+++ b/src/main/kotlin/com/intershop/gradle/resourcelist/task/ResourceListFileTask.kt
@@ -39,11 +39,6 @@ abstract class ResourceListFileTask
     @Inject constructor(objectFactory: ObjectFactory,
                         private val fileSystemOps: FileSystemOperations) : DefaultTask() {
 
-    /**
-     * The one and only folder searched for resources
-     */
-    private val RESOURCES = "resources"
-
     private val excludesProperty = objectFactory.listProperty(String::class.java)
     private val includesProperty = objectFactory.listProperty(String::class.java)
     private val sourceSetNameProperty = objectFactory.property(String::class.java)
@@ -165,7 +160,7 @@ abstract class ResourceListFileTask
                 if(srcset.name == sourceSetName) {
                     // search in "resources" only
                     (srcset.resources.srcDirs).forEach {srcDir ->
-                        if (RESOURCES == srcDir.name) {
+                        if ("resources" == srcDir.name) {
                             val fileSet = project.fileTree(srcDir) {
                                 it.setIncludes(includes)
                                 it.setExcludes(excludes)


### PR DESCRIPTION
- all pipelet.xml and *.orm files have to be contained in folder 'resources'
- there is no need to search in java sources folders or even in the created folders of the other resource-list plugin (expected to be the reason to let builds fail with messages like 'Failed to calculate the value of task ':business:a_storefront:sld_ch_sf_base:resourceListPipelets' property 'outputDir'.')